### PR TITLE
Changed facade class name same like file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Once this operation completes, the next step is to add the service provider. Ope
 
 The next step is to introduce the facade. Open `app/config/app.php`, and add a new item to the aliases array.
 
-	'Mapper'         => 'Cornford\Googlmapper\Facades\Mapper',
+	'Mapper'         => 'Cornford\Googlmapper\Facades\MapperFacade',
 
 Finally we need to introduce the configuration files into your application/
 

--- a/src/Cornford/Googlmapper/Facades/MapperFacade.php
+++ b/src/Cornford/Googlmapper/Facades/MapperFacade.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Facade;
 
-class Mapper extends Facade {
+class MapperFacade extends Facade {
 
 	protected static function getFacadeAccessor() { return 'mapper'; }
 


### PR DESCRIPTION
Using your documentation, I got error **Class 'Cornford\Googlmapper\Facades\MapperFacade' not found**. After few minutes trying, I noticed that the facade class name is not same as the file name. Changing it solve the issue.