### PR TITLE
Add strip_tags function to skip all html tags when searching location

### DIFF
--- a/src/Cornford/Googlmapper/Mapper.php
+++ b/src/Cornford/Googlmapper/Mapper.php
@@ -118,6 +118,7 @@ class Mapper extends MapperBase implements MappingInterface {
 	 */
 	public function location($location)
 	{
+		$location = strip_tags($location);
 		if (empty($location)) {
 			throw new MapperArgumentException('Invalid location search term provided.');
 		}


### PR DESCRIPTION
Just to add this function to remove all html tags when searching. Because now i'm using ckeditor and gives me an error when searching location that has a html tag.


Hope this help :) 