### PR TITLE
Check if array key exists for address_components (fixes undefined offset: 0)

### DIFF
--- a/src/Cornford/Googlmapper/Mapper.php
+++ b/src/Cornford/Googlmapper/Mapper.php
@@ -176,7 +176,7 @@ class Mapper extends MapperBase implements MappingInterface {
         $postalCode = null;
 
         foreach ($resultObject->results[0]->address_components as $addressComponent) {
-            if ($addressComponent->types[0] == 'postal_code') {
+            if (count($addressComponent->types) > 0 && $addressComponent->types[0] == 'postal_code') {
                 $postalCode = $addressComponent->long_name;
             }
         }


### PR DESCRIPTION
Some addresses do not return an array of types in address_components.
E.g. test with location "VAN SWIETENPLEIN GRONINGEN". 
This PR fixes the "Undefined offset: 0" error thrown.