### PR TITLE
Allow decimal values for `fillOpacity` and `strokeOpacity` icon properties

### DIFF
--- a/resources/views/marker.blade.php
+++ b/resources/views/marker.blade.php
@@ -78,7 +78,8 @@ var marker_{!! $id !!} = new google.maps.Marker({
                 @foreach ($options['icon'] as $key => $value)
 
                     @switch($key)
-@case('symbol')
+                        
+                        @case('symbol')
                             path: google.maps.SymbolPath.{!! $value !!},
                         @break;
 
@@ -101,12 +102,15 @@ var marker_{!! $id !!} = new google.maps.Marker({
                             @endif
                         @break;
 
-                        @case('fillOpacity')
                         @case('rotation')
                         @case('scale')
-                        @case('strokeOpacity')
                         @case('strokeWeight')
                             {!! $key !!}: {!! json_encode((int) $value) !!},
+                        @break
+
+                        @case('fillOpacity')
+                        @case('strokeOpacity')
+                            {!! $key !!}: {!! json_encode((float) $value) !!},
                         @break
 
                         @default


### PR DESCRIPTION
Previously, these two properties were cast as an `int`. This PR changes this to cast the properties as a `float` so as to allow decimal values like `0.8`.